### PR TITLE
Apanagio patch 1

### DIFF
--- a/src/ndt7-download-worker.js
+++ b/src/ndt7-download-worker.js
@@ -17,7 +17,7 @@ const workerMain = function(ev) {
   let now = () => new Date().getTime();
   if (typeof performance !== 'undefined' &&
       typeof performance.now !== 'undefined') {
-    now = performance.now;
+    now = () => performance.now();
   }
   downloadTest(sock, postMessage, now);
 };

--- a/src/ndt7-upload-worker.js
+++ b/src/ndt7-upload-worker.js
@@ -16,7 +16,7 @@ const workerMain = function(ev) {
   let now = () => new Date().getTime();
   if (typeof performance !== 'undefined' &&
       typeof performance.now !== 'undefined') {
-    now = performance.now;
+    now = () => performance.now();
   }
   uploadTest(sock, postMessage, now);
 };


### PR DESCRIPTION
It seems that calls to performance.now() need a specific context. It raises an error in firefox and chrome when called outside this context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-js/12)
<!-- Reviewable:end -->
