### PR TITLE
Update e2e testing to use sandbox

### DIFF
--- a/src/test/e2e/index.html
+++ b/src/test/e2e/index.html
@@ -23,7 +23,7 @@
                 userAcceptedDataPolicy: true,
                 downloadworkerfile: 'ndt7-download-worker.min.js',
                 uploadworkerfile: 'ndt7-upload-worker.min.js',
-                loadbalancer: 'https://locate-dot-mlab-staging.appspot.com/v2/nearest/ndt/ndt7'
+                loadbalancer: 'https://locate-dot-mlab-sandbox.appspot.com/v2/nearest/ndt/ndt7'
             },
             {
                 serverChosen: (server) => {


### PR DESCRIPTION
This PR changes the e2e test to target sandbox machines. It's not completely clear yet how this will affect browserstack tests' flakiness (RTT between the VM and the M-Lab server might increase a lot) but this should prevent alerts firing in staging due to lower-than-usual test volume whenever the daily e2e tests fail for a day or two in a row.